### PR TITLE
Fix loadXML() sometimes cause a waring.

### DIFF
--- a/lib/Bs/IDeal/IDeal.php
+++ b/lib/Bs/IDeal/IDeal.php
@@ -188,7 +188,7 @@ class IDeal
     protected function handleResult(Request\Request $request, $headers, $document)
     {
         $doc = new DOMDocument();
-        if ($doc->loadXML($document)) {
+        if (!empty($document) && $doc->loadXML($document)) {
             $response = null;
             switch ($doc->documentElement->tagName) {
                 case 'AcquirerErrorRes':


### PR DESCRIPTION
Sometimes the curl_exec will return empty,it will cause a waring message and throw an exception.